### PR TITLE
fix: fixed go subpackages build within dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,9 @@ FROM golang:1.23-bookworm AS go-builder
 
 # we get our main module as a binary from the source
 WORKDIR /app
-COPY ./go.mod ./go.sum ./
+COPY go.mod go.sum ./
 RUN go mod download
-COPY ./*.go ./
+COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -o /repeticode
 
 # build using node and vite
@@ -31,6 +31,8 @@ COPY --from=go-builder \
       # copy our binary over
       /repeticode \
       .
+
+COPY .env /app/
 
 COPY --from=frontend-builder \
       # copy over our static html files


### PR DESCRIPTION
## Description
The dockerfile previously copied all go files into the same root folder, ignoring all heirarchal subpackagesthat comprise Go subpackages! This is why everytime I tried introducing subpackages, the Dockerfile would fail when trying to build 🤦  My bad! Now, we just copy everything over with the correct file structure and it all works as it does locally 👍 

## Changes Made
- [ ] Feature Implementation
- [x] Bug Fix
- [ ] Refactoring
- [ ] Documentation Update
- [ ] Other (please specify):