### PR TITLE
fix: fixed loading env variables within Railway using godotenv

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,12 +8,14 @@ import (
 	"os"
 
 	"github.com/emoral435/repeticode/auth"
+	"github.com/joho/godotenv"
 )
 
 func main() {
 	// create the logger
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 
+	godotenv.Load()
 	// get our keys from the environment
 	key := os.Getenv("HASHING_KEY")
 	if key == "" {
@@ -46,7 +48,6 @@ func main() {
 		Logger: logger,
 	}
 
-	fmt.Printf("clientId: %v\n", googleClientId)
 	if err := auth.InitAuth(key, googleClientId, googleClientSecret); err != nil {
 		logger.Error(fmt.Errorf("error in trying to init auth: %w", err).Error())
 		os.Exit(1)


### PR DESCRIPTION
## Description
previously, with the `godotenv` package, our server was able to correctly read in the `env` variables. Now, we removed it, so we are doing a pseudo rollback to load in our env variables correctly!

## Changes Made
- [ ] Feature Implementation
- [x] Bug Fix
- [ ] Refactoring
- [ ] Documentation Update
- [ ] Other (please specify):