### PR TITLE
fix: centered loading components and deleted higher Tier field that was erroneous

### DIFF
--- a/docs/FIRESTORE_DATABASE.md
+++ b/docs/FIRESTORE_DATABASE.md
@@ -10,7 +10,6 @@ User Document Schema:
 ```go
 type UserDocument struct {
 	UID         string
-	Tier        string
 	CurrentGoal string
 	Metrics     UserDocumentMetrics
 	Settings    UserDocumentSettings

--- a/firestore.go
+++ b/firestore.go
@@ -10,7 +10,6 @@ import (
 
 type UserDocument struct {
 	UID         string
-	Tier        string
 	CurrentGoal string
 	Metrics     UserDocumentMetrics
 	Settings    UserDocumentSettings

--- a/frontend/src/context/AuthContextProvider.tsx
+++ b/frontend/src/context/AuthContextProvider.tsx
@@ -1,6 +1,7 @@
 import { getAuth, onAuthStateChanged, User } from "firebase/auth";
 import { useEffect, useState } from "react";
 import { AuthContext } from "./AuthContext";
+import { useTheme } from "./ThemeContext";
 
 interface AuthContextProps {
   children: React.ReactNode
@@ -10,6 +11,8 @@ const AuthContextProvider: React.FC<AuthContextProps> = ({children}) => {
   const auth = getAuth();
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
+
+  const {cssThemes} = useTheme();
 
   useEffect(() => {
     const unsubscribed = onAuthStateChanged(auth, (currentUser) => {
@@ -37,7 +40,17 @@ const AuthContextProvider: React.FC<AuthContextProps> = ({children}) => {
         !loading && children
       }
       {
-        loading && <div>Loading...</div>
+        loading && 
+        <div 
+          style={{
+            backgroundColor: cssThemes.colors.background,
+            backgroundImage: `radial-gradient(${cssThemes.colors.primary} 1px, transparent 0)`,
+          backgroundSize: "20px 20px"
+          }}
+          className="w-screen h-screen flex justify-center items-center"
+        >
+          Loading...
+        </div>
       }
     </AuthContext.Provider>
   )

--- a/server.go
+++ b/server.go
@@ -156,7 +156,6 @@ func (rtr *router) EmailRegister(w http.ResponseWriter, r *http.Request) {
 
 	newUserDocument := &UserDocument{
 		UID:         createdUser.UID,
-		Tier:        "Free",
 		CurrentGoal: "Unchosen!",
 		Metrics: UserDocumentMetrics{
 			Height:   0,


### PR DESCRIPTION
## Description
Centers the loading screen, matches its background to more closely align to what we have in the main application, and then also deletes the erroneous field `Tier` that was being made previously.

## Changes Made
- [ ] Feature Implementation
- [x] Bug Fix
- [ ] Refactoring
- [ ] Documentation Update
- [ ] Other (please specify):